### PR TITLE
fix: supposed to be not equals instead

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,7 +10,7 @@ import {PrivyProvider} from "@privy-io/expo";
 import {Wrapper} from "./Wrapper";
 
 export default function App() {
-  if (Constants.expoConfig?.extra?.privyAppId === "<your-app-id>") {
+  if (Constants.expoConfig?.extra?.privyAppId !== "<your-app-id>") {
     return (
       <SafeAreaView>
         <View


### PR DESCRIPTION
This is supposed to check if the appId is not equals to the one set in app.json