### PR TITLE
Add Buffer Polyfill for Message Signing

### DIFF
--- a/entrypoint.js
+++ b/entrypoint.js
@@ -3,6 +3,11 @@
 // Import required polyfills first
 // IMPORTANT: These polyfills must be installed in this order
 import "react-native-get-random-values";
+import { Buffer } from "buffer";
 import "@ethersproject/shims";
+
+// Set global Buffer
+global.Buffer = Buffer;
+
 // Then import the expo router
 import "expo-router/entry";

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@privy-io/expo": "^0.53.1",
     "@privy-io/expo-native-extensions": "^0.0.5",
     "@react-navigation/native": "^7.1.6",
+    "buffer": "^6.0.3",
     "expo": "~53.0.9",
     "expo-apple-authentication": "~7.2.4",
     "expo-application": "~6.1.4",


### PR DESCRIPTION
# Fix: Add Buffer Polyfill for Message Signing

## 🐛 Issue
Users experienced `ReferenceError: Property 'Buffer' doesn't exist` errors when attempting to sign messages with embedded wallets in the Expo starter app.

## 🔧 Solution
- Added `buffer` package dependency
- Imported and set `Buffer` as global variable in `entrypoint.js`
- Placed Buffer polyfill in correct order with other required polyfills

## 📋 Changes
- `package.json`: Added `buffer` dependency
- `entrypoint.js`: Added Buffer import and global assignment

## ✅ Testing
- ✅ Authentication flow works correctly
- ✅ Embedded wallet creation successful
- ✅ Message signing now works without errors
- ✅ No breaking changes to existing functionality

## 🎯 Impact
This fix ensures that all cryptographic operations in embedded wallets work properly in the React Native environment, particularly message signing which is a core wallet feature.

## 📚 Context
React Native doesn't include Node.js globals like `Buffer` by default. Crypto libraries used by Privy's embedded wallets require the Buffer polyfill to function correctly in mobile environments.